### PR TITLE
Add option to specify location of build variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ before_script:
 - git config --global user.email "test@example.com"
 - git config --global user.name "Test User"
 script:
-- sed -i "s/GOVV_TEST_PACKAGE/$(go list|sed 's/\//\\\//g')/g" ./integration-test/app-different-package/main.go
-- sed -i "s/GOVV_TEST_PACKAGE/$(go list|sed 's/\//\\\//g')/g" ./integration-test/test.bats
 - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"
 - test -z "$(golint . | tee /dev/stderr)"
 - test -z "$(go vet -v ./... | tee /dev/stderr)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_script:
 - git config --global user.email "test@example.com"
 - git config --global user.name "Test User"
 script:
+- sed -i "s/GOVV_TEST_PACKAGE/$(go list|sed 's/\//\\\//g')/g" ./integration-test/app-different-package/main.go
+- sed -i "s/GOVV_TEST_PACKAGE/$(go list|sed 's/\//\\\//g')/g" ./integration-test/test.bats
 - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"
 - test -z "$(golint . | tee /dev/stderr)"
 - test -z "$(go vet -v ./... | tee /dev/stderr)"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ Still don’t want to wrap the `go` tool? Well, try `-flags` to retrieve the LDF
 
     $ go build -ldflags="$(govvv -flags)"
 
+## Want to use a different package?
+
+You can pass a `-pkg` argument with the full package name, and `govvv` will 
+set the build variables in that package instead of `main`.  For example:
+
+```
+# build with govvv
+$ govvv build -pkg github.com/myacct/myproj/mypkg
+
+# build with go
+$ go build -ldflags="$(govvv -flags -pkg $(go list ./mypkg))"
+```
+
 
 ## Try govvv today
 

--- a/integration-test/app-different-package/VERSION
+++ b/integration-test/app-different-package/VERSION
@@ -1,0 +1,1 @@
+2.0.1-app-different-package

--- a/integration-test/app-different-package/main.go
+++ b/integration-test/app-different-package/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"GOVV_TEST_PACKAGE/integration-test/app-different-package/mypkg"
+)
+
+func main() {
+	fmt.Printf("Version=%s\n", mypkg.Version)
+	fmt.Printf("BuildDate=%s\n", mypkg.BuildDate)
+	fmt.Printf("GitCommit=%s\n", mypkg.GitCommit)
+	fmt.Printf("GitBranch=%s\n", mypkg.GitBranch)
+	fmt.Printf("GitState=%s\n", mypkg.GitState)
+	fmt.Printf("GitSummary=%s\n", mypkg.GitSummary)
+}

--- a/integration-test/app-different-package/main.go
+++ b/integration-test/app-different-package/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"GOVV_TEST_PACKAGE/integration-test/app-different-package/mypkg"
+	"github.com/ahmetb/govvv/integration-test/app-different-package/mypkg"
 )
 
 func main() {

--- a/integration-test/app-different-package/mypkg/version.go
+++ b/integration-test/app-different-package/mypkg/version.go
@@ -1,0 +1,11 @@
+package mypkg
+
+var (
+	// These fields are populated by govvv
+	BuildDate  string
+	GitCommit  string
+	GitBranch  string
+	GitState   string
+	GitSummary string
+	Version    string
+)

--- a/integration-test/app-versioned/VERSION
+++ b/integration-test/app-versioned/VERSION
@@ -1,1 +1,1 @@
-2.0.1
+2.0.1-app-versioned

--- a/integration-test/test.bats
+++ b/integration-test/test.bats
@@ -140,12 +140,12 @@
 }
 
 @test "govvv compiled with govvv" {
-    run govvv build
+    touch main.go
+    run govvv install
     echo "$output"
     [ "$status" -eq 0 ]
 
-    run ./govvv
+    run govvv
     echo "$output"
     [[ "${lines[1]}" =~ ^version:\ (.*)@[0-9a-f]{4,15}-(dirty|clean)$ ]]
-	rm ./govvv
 }

--- a/integration-test/test.bats
+++ b/integration-test/test.bats
@@ -86,6 +86,34 @@
     [[ "${lines[4]}" =~ ^GitSummary=(.*)$ ]]
 }
 
+@test "govvv build - compile-time variables in different package" {
+    tmp="${BATS_TMPDIR}/a.out"
+
+    run bash -c "cd ${BATS_TEST_DIRNAME}/app-different-package && govvv build -pkg GOVV_TEST_PACKAGE/integration-test/app-different-package/mypkg -o $tmp ."
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    run "$tmp"
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    [[ "${lines[0]}" == "Version=2.0.1-app-different-package" ]]
+    [[ "${lines[1]}" == "BuildDate="*Z ]]
+    [[ "${lines[2]}" =~ ^GitCommit=[0-9a-f]{4,15}$ ]]
+    [[ "${lines[3]}" =~ ^GitBranch=(.*)$ ]]
+    [[ "${lines[4]}" =~ ^GitState=(clean|dirty)$ ]]
+    [[ "${lines[5]}" =~ ^GitSummary=(.*)$ ]]
+}
+
+@test "govvv -flags and -pkg" {
+
+    run bash -c "cd ${BATS_TEST_DIRNAME}/app-different-package && govvv -flags -pkg GOVV_TEST_PACKAGE/integration-test/app-different-package/mypkg ."
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    [[ "$output" =~ -X\ GOVV_TEST_PACKAGE/integration-test/app-different-package/mypkg\.Version=2.0.1-app-different-package ]]
+}
+
 @test "govvv build - preserves given -ldflags" {
     tmp="${BATS_TMPDIR}/a.out"
     run govvv build -o "$tmp" -ldflags="-X main.MyVariable=myValue" ./integration-test/app-extra-ldflags
@@ -108,15 +136,16 @@
     run "$tmp"
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "$output" == "Version=2.0.1" ]]
+    [[ "$output" == "Version=2.0.1-app-versioned" ]]
 }
 
 @test "govvv compiled with govvv" {
-    run govvv install -a
+    run govvv build
     echo "$output"
     [ "$status" -eq 0 ]
 
-    run govvv
+    run ./govvv
     echo "$output"
     [[ "${lines[1]}" =~ ^version:\ (.*)@[0-9a-f]{4,15}-(dirty|clean)$ ]]
+	rm ./govvv
 }

--- a/integration-test/test.bats
+++ b/integration-test/test.bats
@@ -8,21 +8,21 @@
     run govvv
     echo "$output"
     [ "$status" -ne 0 ]
-    [[ "$output" == *"not enough arguments"** ]] 
+    [[ "$output" == *"not enough arguments"** ]]
 }
 
 @test "whitelists certain go commands" {
     run govvv doc
     echo "$output"
     [ "$status" -ne 0 ]
-    [[ "$output" == *'only works with "build", "install" and "list". try "go doc" instead'** ]] 
+    [[ "$output" == *'only works with "build", "install" and "list". try "go doc" instead'** ]]
 }
 
 @test "fails on go tool failure and redirects output" {
     run govvv build -invalid-arg
     echo "$output"
     [ "$status" -ne 0 ]
-    [[ "$output" == *'flag provided but not defined: -invalid-arg'** ]] 
+    [[ "$output" == *'flag provided but not defined: -invalid-arg'** ]]
 }
 
 @test "govvv build - dry run" {
@@ -48,7 +48,7 @@
 
 @test "govvv build - program with no compile-time variables" {
     tmp="${BATS_TMPDIR}/a.out"
-    run govvv build -o "$tmp" ./integration-test/app-empty  
+    run govvv build -o "$tmp" ./integration-test/app-empty
     echo "$output"
     [ "$status" -eq 0 ]
 
@@ -71,7 +71,7 @@
 
 @test "govvv build - program with compile-time variables" {
     tmp="${BATS_TMPDIR}/a.out"
-    run govvv build -o "$tmp" ./integration-test/app-example  
+    run govvv build -o "$tmp" ./integration-test/app-example
     echo "$output"
     [ "$status" -eq 0 ]
 
@@ -89,7 +89,7 @@
 @test "govvv build - compile-time variables in different package" {
     tmp="${BATS_TMPDIR}/a.out"
 
-    run bash -c "cd ${BATS_TEST_DIRNAME}/app-different-package && govvv build -pkg GOVV_TEST_PACKAGE/integration-test/app-different-package/mypkg -o $tmp ."
+    run bash -c "cd ${BATS_TEST_DIRNAME}/app-different-package && govvv build -pkg github.com/ahmetb/govvv/integration-test/app-different-package/mypkg -o $tmp"
     echo "$output"
     [ "$status" -eq 0 ]
 
@@ -107,11 +107,11 @@
 
 @test "govvv -flags and -pkg" {
 
-    run bash -c "cd ${BATS_TEST_DIRNAME}/app-different-package && govvv -flags -pkg GOVV_TEST_PACKAGE/integration-test/app-different-package/mypkg ."
+    run bash -c "cd ${BATS_TEST_DIRNAME}/app-different-package && govvv -flags -pkg github.com/ahmetb/govvv/integration-test/app-different-package/mypkg"
     echo "$output"
     [ "$status" -eq 0 ]
 
-    [[ "$output" =~ -X\ GOVV_TEST_PACKAGE/integration-test/app-different-package/mypkg\.Version=2.0.1-app-different-package ]]
+    [[ "$output" =~ -X\ github.com/ahmetb/govvv/integration-test/app-different-package/mypkg\.Version=2.0.1-app-different-package ]]
 }
 
 @test "govvv build - preserves given -ldflags" {

--- a/main.go
+++ b/main.go
@@ -15,8 +15,10 @@ func init() {
 }
 
 const (
+	defaultPackage       = "main"
 	flDryRun             = "-print"
 	flDryRunPrintLdFlags = "-flags"
+	flPackage            = "-pkg"
 )
 
 func main() {
@@ -25,7 +27,7 @@ func main() {
 		log.Println(`govvv: not enough arguments (try "govvv build .")`)
 		log.Printf("version: %s", versionString())
 		os.Exit(1)
-	} else if args[1] != "build" && args[1] != "install" && args[1] != "list" && args[1] != flDryRunPrintLdFlags {
+	} else if args[1] != "build" && args[1] != "install" && args[1] != "list" && args[1] != flDryRunPrintLdFlags && args[1] != flPackage {
 		// do not wrap the entire 'go tool'
 		// "list" is wrapped to be compatible with mitchellh/gox.
 		log.Fatalf(`govvv: only works with "build", "install" and "list". try "go %s" instead`, args[1])
@@ -35,7 +37,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("govvv: cannot get working directory: %v", err)
 	}
-	vals, err := GetFlags(wd)
+	pkg := defaultPackage
+	args = normalizeArg(args, flPackage)
+	if idx := findArg(args, flPackage); idx != -1 {
+		pkg = strings.Split(args[idx], "=")[1]
+		// remove...can't pass through to go tool
+		args = append(args[:idx], args[idx+1:]...)
+	}
+
+	vals, err := GetFlags(wd, pkg)
 	if err != nil {
 		log.Fatalf("failed to collect values: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func scrubGovvvDirectives(args []string) (filtered []string) {
 	skipping := 0
 	for _, arg := range args {
 		if skipping > 0 {
-			skipping -= 1
+			skipping--
 			continue
 		}
 		if hasArgument, ok := govvvDirectives[arg]; ok {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,9 @@ const (
 )
 
 var (
+	// govvvDirectives is mapping of govvv directives, which must be elided
+	// when constructing the final go tool command, to a boolean which
+	// indicates whether the directive takes an argument or not.
 	govvvDirectives = map[string]bool{flDryRun: false, flDryRunPrintLdFlags: false, flPackage: true}
 )
 
@@ -113,14 +116,14 @@ func goToolDryRunCmd(args []string) string {
 	return b.String()
 }
 
-// isGovvvDirective returns true if the arg is a goov directive, and false
+// isGovvvDirective returns true if the arg is a govvv directive, and false
 // otherwise.
 func isGovvvDirective(arg string) bool {
 	_, ok := govvvDirectives[arg]
 	return ok
 }
 
-// scrubGovvvDirectives filters out goov directs to return a clean set of args
+// scrubGovvvDirectives filters out govvv directs to return a clean set of args
 // that can be passed to the go command.
 func scrubGovvvDirectives(args []string) (filtered []string) {
 	filtered = []string{}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestIsGovvvDirective(t *testing.T) {
+	for directive := range govvvDirectives {
+		require.True(t, isGovvvDirective(directive))
+	}
+
+	require.False(t, isGovvvDirective("-o"))
+}
+
+func TestScrubGovvvDirectives(t *testing.T) {
+	require.Equal(t, []string{}, []string{}, "scrubGovvvDirectives should be fine with an empty arg array")
+
+	require.Equal(t, []string{"build", "-o", "a.out"}, scrubGovvvDirectives([]string{"build", "-o", "a.out"}),
+		"scrubGovvvDirectives should not touch normal go args")
+
+	require.Equal(t, []string{}, scrubGovvvDirectives([]string{"-flags"}),
+		"scrubGovvvDirectives should scrub -flags")
+
+	require.Equal(t, []string{"build", "-o", "a.out"}, scrubGovvvDirectives([]string{"build", "-o", "a.out", "-print"}),
+		"scrubGovvvDirectives should scrub -print")
+
+	require.Equal(t, []string{"build", "-o", "a.out"},
+		scrubGovvvDirectives([]string{"build", "-o", "a.out", "-pkg", "github.com/ahmetb/govvv"}),
+		"scrubGovvvDirectives should scrub -pkg and its argument")
+}
+
+func TestCollectGovvvDirective(t *testing.T) {
+	argument, ok := collectGovvvDirective([]string{}, flDryRun)
+	require.False(t, ok)
+	require.Equal(t, "", argument, "collectGovvvDirective should be fine with an empty arg array")
+
+	argument, ok = collectGovvvDirective([]string{"build", "-o", "a.out", "-print"}, flDryRun)
+	require.True(t, ok)
+	require.Equal(t, "", argument, "collectGovvvDirective should find -print")
+
+	argument, ok = collectGovvvDirective([]string{"-flags"}, flDryRunPrintLdFlags)
+	require.True(t, ok)
+	require.Equal(t, "", argument, "collectGovvvDirective should find -flags")
+
+	argument, ok = collectGovvvDirective([]string{"build", "-o", "a.out", "-pkg", "github.com/ahmetb/govvv"}, flPackage)
+	require.True(t, ok)
+	require.Equal(t, "github.com/ahmetb/govvv", argument, "collectGovvvDirective should find -pkg")
+
+	argument, ok = collectGovvvDirective([]string{"build", "-o", "a.out", "-pkg"}, flPackage)
+	require.False(t, ok)
+	require.Equal(t, "", argument, "collectGovvvDirective should catch missing argument for -pkg")
+}

--- a/values.go
+++ b/values.go
@@ -12,7 +12,7 @@ import (
 const versionFile = "VERSION"
 
 // GetFlags collects data to be passed as ldflags.
-func GetFlags(dir string) (map[string]string, error) {
+func GetFlags(dir, pkg string) (map[string]string, error) {
 	repo := git{dir}
 	gitBranch := repo.Branch()
 	gitCommit, err := repo.Commit()
@@ -29,17 +29,17 @@ func GetFlags(dir string) (map[string]string, error) {
 	}
 
 	v := map[string]string{
-		"main.BuildDate":  date(),
-		"main.GitCommit":  gitCommit,
-		"main.GitBranch":  gitBranch,
-		"main.GitState":   gitState,
-		"main.GitSummary": gitSummary,
+		pkg + ".BuildDate":  date(),
+		pkg + ".GitCommit":  gitCommit,
+		pkg + ".GitBranch":  gitBranch,
+		pkg + ".GitState":   gitState,
+		pkg + ".GitSummary": gitSummary,
 	}
 
 	if version, err := versionFromFile(dir); err != nil {
 		return nil, fmt.Errorf("failed to get version: %v", err)
 	} else if version != "" {
-		v["main.Version"] = version
+		v[pkg+".Version"] = version
 	}
 
 	return v, nil

--- a/values_test.go
+++ b/values_test.go
@@ -13,7 +13,7 @@ func TestGetValues_error(t *testing.T) {
 	repo := newRepo(t)
 	defer os.RemoveAll(repo.dir)
 
-	_, err := GetFlags(repo.dir)
+	_, err := GetFlags(repo.dir, "main")
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to get commit")
 }
@@ -31,7 +31,7 @@ func TestGetValues(t *testing.T) {
 	mkCommit(t, repo, "commit 2")
 
 	// read the flags
-	fl, err := GetFlags(repo.dir)
+	fl, err := GetFlags(repo.dir, "main")
 	require.Nil(t, err)
 
 	// validate the flags
@@ -49,15 +49,35 @@ func TestGetValues_versionFlag(t *testing.T) {
 	mkCommit(t, repo, "commit 1")
 
 	// there is no main.Version flag
-	fl, err := GetFlags(repo.dir)
+	fl, err := GetFlags(repo.dir, "main")
 	require.Nil(t, err)
 	require.Empty(t, fl["main.Version"])
 
 	// add version file and get the value back
 	require.Nil(t, ioutil.WriteFile(filepath.Join(repo.dir, "VERSION"), []byte("2.0.0-beta\n"), 0600))
-	fl, err = GetFlags(repo.dir)
+	fl, err = GetFlags(repo.dir, "main")
 	require.Nil(t, err)
 	require.Equal(t, "2.0.0-beta", fl["main.Version"])
+}
+
+func TestGetValues_pkgFlag(t *testing.T) {
+	// prepare the repo
+	repo := newRepo(t)
+	defer os.RemoveAll(repo.dir)
+	mkCommit(t, repo, "commit 1")
+	mkCommit(t, repo, "commit 2")
+
+	// read the flags for custom package
+	pkg := "github.com/acct/coolproject/version"
+	fl, err := GetFlags(repo.dir, pkg)
+	require.Nil(t, err)
+
+	// validate the flags
+	require.Contains(t, fl, pkg+".BuildDate")
+	require.Contains(t, fl, pkg+".GitCommit")
+	require.Contains(t, fl, pkg+".GitBranch")
+	require.Contains(t, fl, pkg+".GitState")
+	require.Contains(t, fl, pkg+".GitSummary")
 }
 
 func Test_versionFromFile_notFound(t *testing.T) {


### PR DESCRIPTION
Currently, the build variables' location is hardcoded to the package
main.  This change adds a -pkg option that allows the default package
location to be overridden.