### PR TITLE
Add option to specify version to be used in build variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stop worrying about `-ldflags` and **`go get github.com/ahmetb/govvv`** now.
 | **`main.GitState`** | whether there are uncommitted changes | `clean` or `dirty` | 
 | **`main.GitSummary`** | output of `git describe --tags --dirty --always` | `v1.0.0`, <br/>`v1.0.1-5-g585c78f-dirty`, <br/> `fbd157c` |
 | **`main.BuildDate`** | RFC3339 formatted UTC date | `2016-08-04T18:07:54Z` |
-| **`main.Version`** | contents of `./VERSION` file, if exists | `2.0.0` |
+| **`main.Version`** | contents of `./VERSION` file, if exists, or the value passed via the `-version` option | `2.0.0` |
 
 ## Using govvv is easy
 
@@ -69,7 +69,19 @@ $ govvv build -pkg github.com/myacct/myproj/mypkg
 # build with go
 $ go build -ldflags="$(govvv -flags -pkg $(go list ./mypkg))"
 ```
+## Want to use a different version?
 
+You can pass a `-version` argument with the desired version, and `govvv` will 
+use the specified version instead of obtaining it from the `./VERSION` file.
+For example:
+
+```
+# build with govvv
+$ govvv build -version 1.2.3
+
+# build with go
+$ go build -ldflags="$(govvv -flags -version 1.2.3)"
+```
 
 ## Try govvv today
 

--- a/integration-test/app-example/main.go
+++ b/integration-test/app-example/main.go
@@ -4,6 +4,7 @@ import "fmt"
 
 var (
 	// These fields are populated by govvv
+	Version    = "untouched"
 	BuildDate  string
 	GitCommit  string
 	GitBranch  string
@@ -12,6 +13,7 @@ var (
 )
 
 func main() {
+	fmt.Printf("Version=%s\n", Version)
 	fmt.Printf("BuildDate=%s\n", BuildDate)
 	fmt.Printf("GitCommit=%s\n", GitCommit)
 	fmt.Printf("GitBranch=%s\n", GitBranch)

--- a/integration-test/test.bats
+++ b/integration-test/test.bats
@@ -141,7 +141,7 @@
 }
 
 @test "govvv build - reads Version from -version option" {
-    tmp="/Users/acabrera/a.out"
+    tmp="${BATS_TMPDIR}/a.out"
     run bash -c "cd ${BATS_TEST_DIRNAME}/app-example && govvv build -o ${tmp} -version 1.2.3-command-line"
     [ "$status" -eq 0 ]
     echo "$output"

--- a/integration-test/test.bats
+++ b/integration-test/test.bats
@@ -79,11 +79,12 @@
     echo "$output"
     [ "$status" -eq 0 ]
 
-    [[ "${lines[0]}" == "BuildDate="*Z ]]
-    [[ "${lines[1]}" =~ ^GitCommit=[0-9a-f]{4,15}$ ]]
-    [[ "${lines[2]}" =~ ^GitBranch=(.*)$ ]]
-    [[ "${lines[3]}" =~ ^GitState=(clean|dirty)$ ]]
-    [[ "${lines[4]}" =~ ^GitSummary=(.*)$ ]]
+    [[ "${lines[0]}" == "Version=untouched" ]]
+    [[ "${lines[1]}" == "BuildDate="*Z ]]
+    [[ "${lines[2]}" =~ ^GitCommit=[0-9a-f]{4,15}$ ]]
+    [[ "${lines[3]}" =~ ^GitBranch=(.*)$ ]]
+    [[ "${lines[4]}" =~ ^GitState=(clean|dirty)$ ]]
+    [[ "${lines[5]}" =~ ^GitSummary=(.*)$ ]]
 }
 
 @test "govvv build - compile-time variables in different package" {
@@ -137,6 +138,24 @@
     echo "$output"
     [ "$status" -eq 0 ]
     [[ "$output" == "Version=2.0.1-app-versioned" ]]
+}
+
+@test "govvv build - reads Version from -version option" {
+    tmp="/Users/acabrera/a.out"
+    run bash -c "cd ${BATS_TEST_DIRNAME}/app-example && govvv build -o ${tmp} -version 1.2.3-command-line"
+    [ "$status" -eq 0 ]
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    run "$tmp"
+    [ "$status" -eq 0 ]
+
+    [[ "${lines[0]}" == "1.2.3-command-line" ]]
+    [[ "${lines[1]}" == "BuildDate="*Z ]]
+    [[ "${lines[2]}" =~ ^GitCommit=[0-9a-f]{4,15}$ ]]
+    [[ "${lines[3]}" =~ ^GitBranch=(.*)$ ]]
+    [[ "${lines[4]}" =~ ^GitState=(clean|dirty)$ ]]
+    [[ "${lines[5]}" =~ ^GitSummary=(.*)$ ]]
 }
 
 @test "govvv build - ./VERSION file overridden by -version option" {

--- a/integration-test/test.bats
+++ b/integration-test/test.bats
@@ -139,6 +139,18 @@
     [[ "$output" == "Version=2.0.1-app-versioned" ]]
 }
 
+@test "govvv build - ./VERSION file overridden by -version option" {
+    tmp="${BATS_TMPDIR}/a.out"
+    run bash -c "cd ${BATS_TEST_DIRNAME}/app-versioned && govvv build -o ${tmp} -version 1.2.3-command-line"
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    run "$tmp"
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == "Version=1.2.3-command-line" ]]
+}
+
 @test "govvv compiled with govvv" {
     touch main.go
     run govvv install

--- a/integration-test/test.bats
+++ b/integration-test/test.bats
@@ -148,6 +148,7 @@
     [ "$status" -eq 0 ]
 
     run "$tmp"
+    echo "$output"
     [ "$status" -eq 0 ]
 
     [[ "${lines[0]}" == "1.2.3-command-line" ]]

--- a/integration-test/test.bats
+++ b/integration-test/test.bats
@@ -71,7 +71,7 @@
 
 @test "govvv build - program with compile-time variables" {
     tmp="${BATS_TMPDIR}/a.out"
-    run govvv build -o "$tmp" ./integration-test/app-example
+    run bash -c "cd ${BATS_TEST_DIRNAME}/app-example && govvv build -o ${tmp}"
     echo "$output"
     [ "$status" -eq 0 ]
 
@@ -151,7 +151,7 @@
     echo "$output"
     [ "$status" -eq 0 ]
 
-    [[ "${lines[0]}" == "1.2.3-command-line" ]]
+    [[ "${lines[0]}" == "Version=1.2.3-command-line" ]]
     [[ "${lines[1]}" == "BuildDate="*Z ]]
     [[ "${lines[2]}" =~ ^GitCommit=[0-9a-f]{4,15}$ ]]
     [[ "${lines[3]}" =~ ^GitBranch=(.*)$ ]]

--- a/main.go
+++ b/main.go
@@ -19,13 +19,14 @@ const (
 	flDryRun             = "-print"
 	flDryRunPrintLdFlags = "-flags"
 	flPackage            = "-pkg"
+	flVersion            = "-version"
 )
 
 var (
 	// govvvDirectives is mapping of govvv directives, which must be elided
 	// when constructing the final go tool command, to a boolean which
 	// indicates whether the directive takes an argument or not.
-	govvvDirectives = map[string]bool{flDryRun: false, flDryRunPrintLdFlags: false, flPackage: true}
+	govvvDirectives = map[string]bool{flDryRun: false, flDryRunPrintLdFlags: false, flPackage: true, flVersion: true}
 )
 
 func main() {
@@ -54,6 +55,17 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to collect values: %v", err)
 	}
+
+	// calculate the version
+	version, err := versionFromFile(wd)
+	if err != nil {
+		log.Fatalf("failed to get version: %v", err)
+	}
+	if value, ok := collectGovvvDirective(args, flVersion); ok {
+		version = value
+	}
+	versionValues[pkg+".Version"] = version
+
 	ldflags, err := mkLdFlags(versionValues)
 	if err != nil {
 		log.Fatalf("failed to compile values: %v", err)

--- a/main.go
+++ b/main.go
@@ -26,7 +26,11 @@ var (
 	// govvvDirectives is mapping of govvv directives, which must be elided
 	// when constructing the final go tool command, to a boolean which
 	// indicates whether the directive takes an argument or not.
-	govvvDirectives = map[string]bool{flDryRun: false, flDryRunPrintLdFlags: false, flPackage: true, flVersion: true}
+	govvvDirectives = map[string]bool{
+		flDryRun:             false,
+		flDryRunPrintLdFlags: false,
+		flPackage:            true,
+		flVersion:            true}
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -46,25 +46,10 @@ func main() {
 		log.Fatalf("govvv: cannot get working directory: %v", err)
 	}
 
-	pkg := defaultPackage
-	if value, ok := collectGovvvDirective(args, flPackage); ok {
-		pkg = value
-	}
-
-	versionValues, err := GetFlags(wd, pkg)
+	versionValues, err := GetFlags(wd, args)
 	if err != nil {
 		log.Fatalf("failed to collect values: %v", err)
 	}
-
-	// calculate the version
-	version, err := versionFromFile(wd)
-	if err != nil {
-		log.Fatalf("failed to get version: %v", err)
-	}
-	if value, ok := collectGovvvDirective(args, flVersion); ok {
-		version = value
-	}
-	versionValues[pkg+".Version"] = version
 
 	ldflags, err := mkLdFlags(versionValues)
 	if err != nil {

--- a/values.go
+++ b/values.go
@@ -12,7 +12,7 @@ import (
 const versionFile = "VERSION"
 
 // GetFlags collects data to be passed as ldflags.
-func GetFlags(dir string, args [] string) (map[string]string, error) {
+func GetFlags(dir string, args []string) (map[string]string, error) {
 	repo := git{dir}
 	gitBranch := repo.Branch()
 	gitCommit, err := repo.Commit()

--- a/values.go
+++ b/values.go
@@ -12,7 +12,7 @@ import (
 const versionFile = "VERSION"
 
 // GetFlags collects data to be passed as ldflags.
-func GetFlags(dir, pkg string) (map[string]string, error) {
+func GetFlags(dir string, args [] string) (map[string]string, error) {
 	repo := git{dir}
 	gitBranch := repo.Branch()
 	gitCommit, err := repo.Commit()
@@ -28,12 +28,30 @@ func GetFlags(dir, pkg string) (map[string]string, error) {
 		return nil, fmt.Errorf("failed to get repository summary: %v", err)
 	}
 
+	// prefix keys with package to be used by ldflags -X
+	pkg := defaultPackage
+	if value, ok := collectGovvvDirective(args, flPackage); ok {
+		pkg = value
+	}
+
 	v := map[string]string{
 		pkg + ".BuildDate":  date(),
 		pkg + ".GitCommit":  gitCommit,
 		pkg + ".GitBranch":  gitBranch,
 		pkg + ".GitState":   gitState,
 		pkg + ".GitSummary": gitSummary,
+	}
+
+	// calculate the version
+	if value, ok := collectGovvvDirective(args, flVersion); ok {
+		v[pkg+".Version"] = value
+	} else {
+		value, err := versionFromFile(dir)
+		if err != nil {
+			return nil, err
+		} else if value != "" {
+			v[pkg+".Version"] = value
+		}
 	}
 
 	return v, nil

--- a/values.go
+++ b/values.go
@@ -36,12 +36,6 @@ func GetFlags(dir, pkg string) (map[string]string, error) {
 		pkg + ".GitSummary": gitSummary,
 	}
 
-	if version, err := versionFromFile(dir); err != nil {
-		return nil, fmt.Errorf("failed to get version: %v", err)
-	} else if version != "" {
-		v[pkg+".Version"] = version
-	}
-
 	return v, nil
 }
 

--- a/values_test.go
+++ b/values_test.go
@@ -13,7 +13,7 @@ func TestGetValues_error(t *testing.T) {
 	repo := newRepo(t)
 	defer os.RemoveAll(repo.dir)
 
-	_, err := GetFlags(repo.dir, "main")
+	_, err := GetFlags(repo.dir, []string{})
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "failed to get commit")
 }
@@ -31,7 +31,7 @@ func TestGetValues(t *testing.T) {
 	mkCommit(t, repo, "commit 2")
 
 	// read the flags
-	fl, err := GetFlags(repo.dir, "main")
+	fl, err := GetFlags(repo.dir, []string{})
 	require.Nil(t, err)
 
 	// validate the flags
@@ -51,7 +51,7 @@ func TestGetValues_pkgFlag(t *testing.T) {
 
 	// read the flags for custom package
 	pkg := "github.com/acct/coolproject/version"
-	fl, err := GetFlags(repo.dir, pkg)
+	fl, err := GetFlags(repo.dir, []string{flPackage, pkg})
 	require.Nil(t, err)
 
 	// validate the flags

--- a/values_test.go
+++ b/values_test.go
@@ -42,24 +42,6 @@ func TestGetValues(t *testing.T) {
 	require.Equal(t, fl["main.GitCommit"], fl["main.GitSummary"])
 }
 
-func TestGetValues_versionFlag(t *testing.T) {
-	// prepare the repo
-	repo := newRepo(t)
-	defer os.RemoveAll(repo.dir)
-	mkCommit(t, repo, "commit 1")
-
-	// there is no main.Version flag
-	fl, err := GetFlags(repo.dir, "main")
-	require.Nil(t, err)
-	require.Empty(t, fl["main.Version"])
-
-	// add version file and get the value back
-	require.Nil(t, ioutil.WriteFile(filepath.Join(repo.dir, "VERSION"), []byte("2.0.0-beta\n"), 0600))
-	fl, err = GetFlags(repo.dir, "main")
-	require.Nil(t, err)
-	require.Equal(t, "2.0.0-beta", fl["main.Version"])
-}
-
 func TestGetValues_pkgFlag(t *testing.T) {
 	// prepare the repo
 	repo := newRepo(t)

--- a/values_test.go
+++ b/values_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetValues_error(t *testing.T) {
+func TestGetFlags_error(t *testing.T) {
 	repo := newRepo(t)
 	defer os.RemoveAll(repo.dir)
 
@@ -23,7 +23,7 @@ func Test_date(t *testing.T) {
 	require.Regexp(t, "^[0-9]{4}(-[0-9]{2}){2}T([0-9]{2}:){2}[0-9]{2}Z$", v)
 }
 
-func TestGetValues(t *testing.T) {
+func TestGetFlags(t *testing.T) {
 	// prepare the repo
 	repo := newRepo(t)
 	defer os.RemoveAll(repo.dir)
@@ -42,7 +42,72 @@ func TestGetValues(t *testing.T) {
 	require.Equal(t, fl["main.GitCommit"], fl["main.GitSummary"])
 }
 
-func TestGetValues_pkgFlag(t *testing.T) {
+func TestGetFlags_versionDefault(t *testing.T) {
+	// prepare the repo
+	repo := newRepo(t)
+	defer os.RemoveAll(repo.dir)
+	mkCommit(t, repo, "commit 1")
+
+	// there is no main.Version flag
+	fl, err := GetFlags(repo.dir, []string{})
+	require.Nil(t, err)
+	require.NotContains(t, fl, "main.Version")
+}
+
+func TestGetFlags_justVersionFlag(t *testing.T) {
+	// prepare the repo
+	repo := newRepo(t)
+	defer os.RemoveAll(repo.dir)
+	mkCommit(t, repo, "commit 1")
+
+	// -version is specified and there is no VERSION file
+	fl, err := GetFlags(repo.dir, []string{flVersion, "2.0.0-RC01"})
+	require.Nil(t, err)
+	require.Equal(t, "2.0.0-RC01", fl["main.Version"])
+}
+
+func TestGetFlags_versionFile(t *testing.T) {
+	// prepare the repo
+	repo := newRepo(t)
+	defer os.RemoveAll(repo.dir)
+	mkCommit(t, repo, "commit 1")
+
+	// add version file and get the value back
+	require.Nil(t, ioutil.WriteFile(filepath.Join(repo.dir, "VERSION"), []byte("2.0.0-beta\n"), 0600))
+	fl, err := GetFlags(repo.dir, []string{})
+	require.Nil(t, err)
+	require.Equal(t, "2.0.0-beta", fl["main.Version"])
+}
+
+func TestGetFlags_versionFlagOverrides(t *testing.T) {
+	// prepare the repo
+	repo := newRepo(t)
+	defer os.RemoveAll(repo.dir)
+	mkCommit(t, repo, "commit 1")
+
+	// add version file
+	require.Nil(t, ioutil.WriteFile(filepath.Join(repo.dir, "VERSION"), []byte("2.0.0-beta\n"), 0600))
+
+	// -version is specified and there is na VERSION file (flag takes precedence)
+	fl, err := GetFlags(repo.dir, []string{flVersion, "2.0.0-RC01"})
+	require.Nil(t, err)
+	require.Equal(t, "2.0.0-RC01", fl["main.Version"])
+}
+
+func TestGetFlags_versionFileError(t *testing.T) {
+	// prepare the repo
+	repo := newRepo(t)
+	defer os.RemoveAll(repo.dir)
+	mkCommit(t, repo, "commit 1")
+
+	// add version file and get the value back
+	require.Nil(t, ioutil.WriteFile(filepath.Join(repo.dir, "VERSION"), []byte("2.0.0-beta\n"), 0000))
+	fl, err := GetFlags(repo.dir, []string{})
+	require.Nil(t, fl)
+	require.Contains(t, err.Error(), "failed to read version file")
+}
+
+func TestGetFlags_pkgFlag(t *testing.T) {
 	// prepare the repo
 	repo := newRepo(t)
 	defer os.RemoveAll(repo.dir)
@@ -66,7 +131,8 @@ func Test_versionFromFile_notFound(t *testing.T) {
 	dir := tmpDir(t)
 	defer os.RemoveAll(dir)
 
-	_, err := versionFromFile(dir)
+	v, err := versionFromFile(dir)
+	require.Equal(t, "", v)
 	require.Nil(t, err)
 }
 


### PR DESCRIPTION
Forcing people to use the ./VERSION file seems to be a bit arbitrary.
Especially if pre-existing tooling pipelines don't support it.  It would
be nice if there was something like a -version option to set this value.