### PR TITLE
Add main.GitCommitMsg

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Stop worrying about `-ldflags` and **`go get github.com/ahmetb/govvv`** now.
 | Variable | Description | Example |
 |----------|-------------|---------|
 | **`main.GitCommit`** | short commit hash of source tree | `0b5ed7a` |
+| **`main.GitCommitMsg`** | output of `git log -1 --pretty=%B` | `Initial commit` |
 | **`main.GitBranch`** | current branch name the code is built off | `master` |
 | **`main.GitState`** | whether there are uncommitted changes | `clean` or `dirty` | 
 | **`main.GitSummary`** | output of `git describe --tags --dirty --always` | `v1.0.0`, <br/>`v1.0.1-5-g585c78f-dirty`, <br/> `fbd157c` |

--- a/git.go
+++ b/git.go
@@ -31,7 +31,7 @@ func (g git) Commit() (string, error) {
 
 // CommitMsg returns the commit message of the most recent commit
 func (g git) CommitMsg() (string, error) {
-	return g.exec("log", "-1", "--pretty=%%B")
+	return g.exec("log", "-1", "--pretty=%B")
 }
 
 // State returns the repository state indicating whether

--- a/git.go
+++ b/git.go
@@ -29,6 +29,11 @@ func (g git) Commit() (string, error) {
 	return g.exec("rev-parse", "--short", "HEAD")
 }
 
+// CommitMsg returns the commit message of the most recent commit
+func (g git) CommitMsg() (string, error) {
+	return g.exec("log", "-1", "--pretty=%%B")
+}
+
 // State returns the repository state indicating whether
 // it is "clean" or "dirty".
 func (g git) State() (string, error) {

--- a/ldflags.go
+++ b/ldflags.go
@@ -15,12 +15,13 @@ func mkLdFlags(values map[string]string) (string, error) {
 		if len(strings.Fields(k)) > 1 {
 			return "", fmt.Errorf("cannot make ldflags for %q: key contains whitespaces", k)
 		}
+		ldFlag := fmt.Sprintf("-X %s=%s", k, v)
 		if len(strings.Fields(v)) > 1 {
-			v = fmt.Sprintf("'%s'", v) // surround it with single quotes
+			ldFlag = fmt.Sprintf("-X '%s=%s'", k, v) // surround the value with single quotes
 		}
 
 		i++
-		b.WriteString(fmt.Sprintf("-X %s=%s", k, v))
+		b.WriteString(ldFlag)
 		if i != len(values) {
 			b.WriteByte(' ')
 		}

--- a/values.go
+++ b/values.go
@@ -19,6 +19,10 @@ func GetFlags(dir string, args []string) (map[string]string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit: %v", err)
 	}
+	gitCommitMsg, err := repo.CommitMsg()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit message: %v", err)
+	}
 	gitState, err := repo.State()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get repository state: %v", err)
@@ -35,11 +39,12 @@ func GetFlags(dir string, args []string) (map[string]string, error) {
 	}
 
 	v := map[string]string{
-		pkg + ".BuildDate":  date(),
-		pkg + ".GitCommit":  gitCommit,
-		pkg + ".GitBranch":  gitBranch,
-		pkg + ".GitState":   gitState,
-		pkg + ".GitSummary": gitSummary,
+		pkg + ".BuildDate":    date(),
+		pkg + ".GitCommit":    gitCommit,
+		pkg + ".GitCommitMsg": gitCommitMsg,
+		pkg + ".GitBranch":    gitBranch,
+		pkg + ".GitState":     gitState,
+		pkg + ".GitSummary":   gitSummary,
 	}
 
 	// calculate the version


### PR DESCRIPTION
`govvv` is amazing as-is, but I felt that being able to fetch the latest commit's message would be very helpful for not only myself but any others looking to utilize developer messages alongside their git versioning for any public or private releases of their programs. This works completely for me and even comes with a small little bug workaround, so I hope this gets accepted and someone appreciates the work already being done for them (because it took me longer to fix the bug than to add GitCommitMsg) c: